### PR TITLE
feat: add propName plugin option

### DIFF
--- a/packages/storyblok-rich-text-vue-renderer/src/composables/useRenderer.ts
+++ b/packages/storyblok-rich-text-vue-renderer/src/composables/useRenderer.ts
@@ -64,11 +64,12 @@ export function useRenderer(options: Options = {}) {
     const components: VNode[] = [];
 
     node.attrs.body.forEach((body) => {
+      const propName = options.propName || 'body';
       const { component } = body;
       const resolver =
         componentResolvers[component] || componentResolvers._fallback;
 
-      components.push(h(resolver, { props: { body } }));
+      components.push(h(resolver, { props: { [propName]: body } }));
     });
 
     return components;

--- a/packages/storyblok-rich-text-vue-renderer/src/index.ts
+++ b/packages/storyblok-rich-text-vue-renderer/src/index.ts
@@ -10,6 +10,7 @@ export interface ResolverOptions {
 
 export interface Options {
   componentName?: string;
+  propName?: string;
   resolvers?: ResolverOptions;
 }
 


### PR DESCRIPTION
Hello, I'm not sure if this project is still alive bu I have the same problem as https://github.com/MarvinRudolph/storyblok-rich-text-renderer/issues/10#issuecomment-933737270 so I added a `propName` option to change the name of the prop used to pass the storyblok data to the component (currently `body`).

```javascript
Vue.use(RichTextRenderer, {
  propName: 'blok',
  resolvers: {
    blocks: {
      [Block.PARAGRAPH]: CustomParagraph,
    },
    components: {
      // SbButton receive a `blok` prop instead of `body`
      button: SbButton,
    },
  },
});
```