### PR TITLE
fix: allow custom components via plugin options

### DIFF
--- a/packages/storyblok-rich-text-vue-renderer/src/App.vue
+++ b/packages/storyblok-rich-text-vue-renderer/src/App.vue
@@ -230,6 +230,29 @@ const doc = shallowReactive({
       ],
     },
     {
+      type: 'paragraph',
+      content: [
+        {
+          text: '<custom-component :msg="I woooork"></custom-component>',
+          type: 'text'
+        }
+      ]
+    },
+    {
+      type: 'blok',
+      attrs: {
+        id: '489f2970-6787-486a-97c3-6f1e8a99b7a9',
+        body: [
+          {
+            sub: [],
+            _uid: 'i-134324ee-1754-48be-93df-02df1e394733',
+            title: 'Second button!',
+            component: 'custom-component',
+          },
+        ],
+      },
+    },
+    {
       type: 'blok',
       attrs: {
         id: '489f2970-6787-486a-97c3-6f1e8a99b7a9',

--- a/packages/storyblok-rich-text-vue-renderer/src/components/CustomComponent.vue
+++ b/packages/storyblok-rich-text-vue-renderer/src/components/CustomComponent.vue
@@ -1,0 +1,24 @@
+<script setup lang="ts">
+import { defineProps } from 'vue'
+
+const props = defineProps({
+  msg: {
+    type: String,
+    default: 'Awiwi'
+  },
+})
+
+</script>
+<template>
+  <div class="custom-component"> 🥑 {{msg}}</div>
+</template>
+
+<style>
+.custom-component {
+    display: inline-flex;
+    border-radius: 5px;
+    padding: 2.5px 10px;
+    background: #00B3B0;
+    color: white;
+}
+</style>

--- a/packages/storyblok-rich-text-vue-renderer/src/main.ts
+++ b/packages/storyblok-rich-text-vue-renderer/src/main.ts
@@ -1,7 +1,8 @@
-import { createApp } from 'vue';
+import { createApp, h } from 'vue';
 import App from './App.vue';
 import { createRouter, createWebHashHistory } from 'vue-router';
-import { plugin } from './plugin';
+import { plugin  } from './plugin';
+import CustomComponent from './components/CustomComponent.vue';
 
 const router = createRouter({
   history: createWebHashHistory(),
@@ -9,6 +10,12 @@ const router = createRouter({
 });
 
 const app = createApp(App);
-app.use(plugin());
+app.use(plugin({
+  resolvers: {
+    components: {
+      'custom-component': () => h(CustomComponent)
+    }
+  }
+}));
 app.use(router);
 app.mount('#app');

--- a/packages/storyblok-rich-text-vue-renderer/src/plugin.ts
+++ b/packages/storyblok-rich-text-vue-renderer/src/plugin.ts
@@ -19,7 +19,7 @@ export interface PluginOptions {
 export const plugin = (options?: PluginOptions): Plugin => ({
   install(app) {
     const renderer = createRenderer(
-      options?.resolvers || { ...defaultResolvers, components: {} },
+      options?.resolvers ? { ...defaultResolvers, ...options?.resolvers } : { ...defaultResolvers, components: {} },
     );
     app.provide(key, renderer);
   },


### PR DESCRIPTION
# Describe issue

Passing custom resolvers for `bloks` inside via the plugin was overwriting the rest of default resolvers, causing errors.

Also, custom resolvers where not rendered

```
import CustomComponent from './components/CustomComponent.vue';
...
app.use(plugin({
  resolvers: {
    components: {
      'custom-component': () => h(CustomComponent)
    }
  }
}));
```

# Solution

This PR adds a condition to add defaultResolvers when `options.resolvers` is passed to `createRenderer`